### PR TITLE
removed unused code

### DIFF
--- a/parse_date.re
+++ b/parse_date.re
@@ -491,7 +491,6 @@ static timelib_sll timelib_get_frac_nr(const char **ptr)
 	const char *begin, *end;
 	char *str;
 	double tmp_nr = TIMELIB_UNSET;
-	int len = 0;
 
 	while ((**ptr != '.') && (**ptr != ':') && ((**ptr < '0') || (**ptr > '9'))) {
 		if (**ptr == '\0') {
@@ -502,7 +501,6 @@ static timelib_sll timelib_get_frac_nr(const char **ptr)
 	begin = *ptr;
 	while ((**ptr == '.') || (**ptr == ':') || ((**ptr >= '0') && (**ptr <= '9'))) {
 		++*ptr;
-		++len;
 	}
 	end = *ptr;
 	str = timelib_calloc(1, end - begin);


### PR DESCRIPTION
Аfter updating mac os developer tools, clang started throwing an error about unused code: variable 'len' set but not used