### PR TITLE
Corrected including of GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,13 @@ cmake_minimum_required(VERSION 3.14..3.18)
 #
 #   cpack
 #   sudo dpkg -i kphp-timelib_*.deb
-
-# Included for CMAKE_INSTALL_PREFIX and other variables.
-include(GNUInstallDirs)
-
 project(kphp-timelib
         VERSION 1.0.0
         DESCRIPTION "timelib 2020.02 library fork for KPHP"
         HOMEPAGE_URL "https://github.com/derickr/timelib")
+
+# Included for CMAKE_INSTALL_PREFIX and other variables.
+include(GNUInstallDirs)
 
 set(BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(OBJS_DIR "${BASE_DIR}/objs")


### PR DESCRIPTION
Fixed GNUInstallDirs connection. It must be done after the project is announced. Otherwise, the system architecture is determined incorrectly.

```
CMake Warning (dev) at /usr/share/cmake/Modules/GNUInstallDirs.cmake:253 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:17 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

```

After which CMAKE_INSTALL_LIBDIR is defined as /usr/lib instead of /usr/lib64

This patch fixes a bug with determining the system architecture.