### PR TITLE
Adjust build options for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(kphp-timelib PRIVATE -Wno-implicit-fallthrough)
   endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(kphp-timelib PRIVATE -Wuninitialized)
+  target_compile_options(kphp-timelib PRIVATE -Wuninitialized -Wno-implicit-fallthrough)
 endif()
 
 set_target_properties(kphp-timelib PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${OBJS_DIR})


### PR DESCRIPTION
Some versions of `clang` (especially `clang-10`) fires false-positive warning in function `do_adjust_timezone` of `tm2unixtime.c`:
```
tm2unixtime.c:447:8: error: this statement may fall through [-Werror=implicit-fallthrough=]
  447 |    tzi = tz->tz_info;
      |    ~~~~^~~~~~~~~~~~~
tm2unixtime.c:450:3: note: here
  450 |   default:
      |   ^~~~~~~
```

Following code leads to the error:
```
case TIMELIB_ZONETYPE_ID:
  tzi = tz->tz_info;
  /* Break intentionally missing */

default:
```

This PR provides extra option `-Wno-implicit-fallthrough` for suppressing `clang` warnings.  